### PR TITLE
Improve 'Get Image' Query

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,9 +155,9 @@
 
 					// set coords of marker
 				    var temp_marker = [lng, lat];
-				  	// create the popup - use parameters 
+				  	// create the popup - use parameters
 				    var popup = new mapboxgl.Popup({ offset: 25 })
-				    .setHTML("<b>"+allLocations[i].location+"</b><hr/><img src='media/images/"+$record+".jpg' width='180'/><br/>"+allLocations[i].description+"<hr/><b>Leave a Comment:</b><input type='text' id='comment' name='comment'/><button onclick='postComment("+$record+");'>Submit</button><br/><b>Comments:</b><div class='comments'"+$record+"'>"+comments_html+"</div>");
+				    .setHTML("<b>"+allLocations[i].location+"</b><hr/><img src='queries/getImage.php?record="+$record+"' width='180'/><br/>"+allLocations[i].description+"<hr/><b>Leave a Comment:</b><input type='text' id='comment' name='comment'/><button onclick='postComment("+$record+");'>Submit</button><br/><b>Comments:</b><div class='comments'"+$record+"'>"+comments_html+"</div>");
 
 				    // create DOM element for the marker
 				    var el = document.createElement('div');
@@ -192,7 +192,7 @@
           map.resize();
       });
     });
-    
+
     ///////////////////////////////////////////////////////////////////////////////////////////
     // This function returns a JSON object of a location based on the Zip code in search bar
 	function getObject(){
@@ -234,7 +234,7 @@
 
 	    getAllPoints(lng,lat);
 
-	    
+
 	  })
 	}
 	///////////////////////////////////////////////////////////////////////////////////////////

--- a/queries/getImage.php
+++ b/queries/getImage.php
@@ -1,14 +1,18 @@
 <?php
 
-// $record = $_POST["record"];
+require '../vendor/autoload.php';
 
-$record = "4501";
+$record = $_GET["record"];
 
-
-// In practice, $fileId denotes the _id of an existing file in GridFS
-$fileId = new MongoDB\BSON\ObjectId;
 $bucket = (new MongoDB\Client)->haunted->selectGridFSBucket();
-$data = $bucket->openDownloadStream($fileId);
+$file = $bucket->findOne(["filename" => $record]);
+if (is_null($file)) {
+  http_response_code(404);
+  die();
+}
+header("Content-Type: image/jpeg");
+header("Content-Length: " . $file['length']);
+$data = $bucket->openDownloadStream($file['_id']);
 $out = fopen('php://output', 'w');
 stream_copy_to_stream($data, $out);
 

--- a/queries/getImage.php
+++ b/queries/getImage.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 // $record = $_POST["record"];
 
@@ -7,11 +7,7 @@ $record = "4501";
 
 // In practice, $fileId denotes the _id of an existing file in GridFS
 $fileId = new MongoDB\BSON\ObjectId;
-
 $bucket = (new MongoDB\Client)->haunted->selectGridFSBucket();
-
-$file = fopen('/path/to/my-output-file.txt', 'wb');
-
-$bucket->downloadToStream($fileId, $file);
-
+$data = $bucket->openDownloadStream($fileId);
+stream_copy_to_stream($data,'php://output')
 ?>

--- a/queries/getImage.php
+++ b/queries/getImage.php
@@ -9,5 +9,7 @@ $record = "4501";
 $fileId = new MongoDB\BSON\ObjectId;
 $bucket = (new MongoDB\Client)->haunted->selectGridFSBucket();
 $data = $bucket->openDownloadStream($fileId);
-stream_copy_to_stream($data,'php://output')
+$out = fopen('php://output', 'w');
+stream_copy_to_stream($data, $out);
+
 ?>


### PR DESCRIPTION
- Improves the `queries/getImage.php` script by switching to a download stream and copying the binary data directly to the output buffer instead of writing to disk. Also provides handling for non-existent images.

- Updates the `index.html` file to use the `getImage` query instead of requesting a static image from the `media` directory.

<img width="747" alt="Screen Shot 2019-03-18 at 22 34 21" src="https://user-images.githubusercontent.com/17786500/54576623-597e0600-49cf-11e9-8350-902a45183d9d.png">
